### PR TITLE
WebRequest: Enable DisableKeepAlive for HTTP connection

### DIFF
--- a/PowerArubaSW/Private/Webrequest.ps1
+++ b/PowerArubaSW/Private/Webrequest.ps1
@@ -39,9 +39,9 @@ function Invoke-ArubaSWWebRequest(){
         
         try {
             if($body){
-                $response = Invoke-WebRequest $fullurl -Method $method -body ($body | ConvertTo-Json) -Websession $sessionvariable
+                $response = Invoke-WebRequest $fullurl -Method $method -body ($body | ConvertTo-Json) -Websession $sessionvariable -DisableKeepAlive
             } else {
-                $response = Invoke-WebRequest $fullurl -Method $method -Websession $sessionvariable
+                $response = Invoke-WebRequest $fullurl -Method $method -Websession $sessionvariable -DisableKeepAlive
             }
         }
         catch {

--- a/PowerArubaSW/Public/Connection.ps1
+++ b/PowerArubaSW/Public/Connection.ps1
@@ -95,7 +95,7 @@ function Connect-ArubaSW {
         }
 
         try {
-            $response = Invoke-WebRequest $url -Method POST -Body ($postParams | Convertto-Json ) -SessionVariable arubasw
+            $response = Invoke-WebRequest $url -Method POST -Body ($postParams | Convertto-Json ) -SessionVariable arubasw -DisableKeepAlive
         }
         catch {
             #$_


### PR DESCRIPTION
it will recreate a TCP connection but it is more fast... (timer when use same HTTP connection?)

With this commit, some tests will be x10 faster !