### PR TITLE
Connection/WebRequest: Add -UseBasicParsing to Invoke-WebRequest

### DIFF
--- a/PowerArubaSW/Private/Webrequest.ps1
+++ b/PowerArubaSW/Private/Webrequest.ps1
@@ -39,9 +39,9 @@ function Invoke-ArubaSWWebRequest(){
         
         try {
             if($body){
-                $response = Invoke-WebRequest $fullurl -Method $method -body ($body | ConvertTo-Json) -Websession $sessionvariable -DisableKeepAlive
+                $response = Invoke-WebRequest $fullurl -Method $method -body ($body | ConvertTo-Json) -Websession $sessionvariable -DisableKeepAlive -UseBasicParsing
             } else {
-                $response = Invoke-WebRequest $fullurl -Method $method -Websession $sessionvariable -DisableKeepAlive
+                $response = Invoke-WebRequest $fullurl -Method $method -Websession $sessionvariable -DisableKeepAlive -UseBasicParsing
             }
         }
         catch {

--- a/PowerArubaSW/Public/Connection.ps1
+++ b/PowerArubaSW/Public/Connection.ps1
@@ -95,7 +95,7 @@ function Connect-ArubaSW {
         }
 
         try {
-            $response = Invoke-WebRequest $url -Method POST -Body ($postParams | Convertto-Json ) -SessionVariable arubasw -DisableKeepAlive
+            $response = Invoke-WebRequest $url -Method POST -Body ($postParams | Convertto-Json ) -SessionVariable arubasw -DisableKeepAlive -UseBasicParsing
         }
         catch {
             #$_


### PR DESCRIPTION
When use PowerShell <= 5 and not logged session (and no IE...), we need to use -UseBasicParsing

Enable by default with PowerShell 6 (Core)

Fix #50