### PR TITLE
Update ShouldProcess for PowerArubaSW

### DIFF
--- a/.vscode/PSScriptAnalyzerSettings.psd1
+++ b/.vscode/PSScriptAnalyzerSettings.psd1
@@ -1,7 +1,6 @@
 @{
     ExcludeRules = @(
         'PSUseToExportFieldsInManifest',
-        'PSUseShouldProcessForStateChangingFunctions',
         'PSUseBOMForUnicodeEncodedFile',
         'PSUseSingularNouns'
     )

--- a/PowerArubaSW/Private/Cookie.ps1
+++ b/PowerArubaSW/Private/Cookie.ps1
@@ -4,7 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-function Set-Cookie($name, $value, $domain, $path = "/") {
+function Set-Cookie() {
+
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessforStateChangingFunctions", "")]
+    Param(
+        [Parameter (Mandatory = $true)]
+        [string]$name,
+        [Parameter (Mandatory = $true)]
+        [string]$value,
+        [Parameter (Mandatory = $true)]
+        [string]$domain,
+        [Parameter (Mandatory = $false)]
+        [string]$path = "/"
+    )
     $c = New-Object System.Net.Cookie;
     $c.Name = $name;
     $c.Path = $path;

--- a/PowerArubaSW/Private/SSL.ps1
+++ b/PowerArubaSW/Private/SSL.ps1
@@ -5,6 +5,8 @@
 #
 Function Set-ArubaSWuntrustedSSL {
 
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessforStateChangingFunctions", "")]
+  Param(  )
   # Hack for allowing untrusted SSL certs with https connections
   Add-Type -TypeDefinition @"
     using System.Net;
@@ -24,6 +26,8 @@ Function Set-ArubaSWuntrustedSSL {
 
 Function Set-ArubaSWCipherSSL {
 
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessforStateChangingFunctions", "")]
+  Param(  )
   # Hack for allowing TLS 1.1 and TLS 1.2 (by default it is only SSL3 and TLS (1.0))
   $AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
   [System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols

--- a/PowerArubaSW/Public/Banner.ps1
+++ b/PowerArubaSW/Public/Banner.ps1
@@ -136,7 +136,7 @@ function Set-ArubaSWBanner {
             }
         }
 
-        if ($PSCmdlet.ShouldProcess("", 'Configure Banner')) {
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Configure Banner')) {
             $response = Invoke-ArubaSWWebRequest -method "PUT" -body $banner -uri $uri -connection $connection
 
             $run = $response | ConvertFrom-Json

--- a/PowerArubaSW/Public/Banner.ps1
+++ b/PowerArubaSW/Public/Banner.ps1
@@ -88,6 +88,7 @@ function Set-ArubaSWBanner {
         Disable is_last_login message
         #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $false)]
         [string]$motd,
@@ -135,11 +136,13 @@ function Set-ArubaSWBanner {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $banner -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess("", 'Configure Banner')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $banner -uri $uri -connection $connection
 
-        $run = $response | ConvertFrom-Json
+            $run = $response | ConvertFrom-Json
 
-        $run
+            $run
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/Connection.ps1
+++ b/PowerArubaSW/Public/Connection.ps1
@@ -203,15 +203,14 @@ function Disconnect-ArubaSW {
         Disconnect the connection
 
         .EXAMPLE
-        Disconnect-ArubaSW -noconfirm
+        Disconnect-ArubaSW -confirm:$false
 
         Disconnect the connection with no confirmation
 
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'high')]
     Param(
-        [Parameter(Mandatory = $false)]
-        [switch]$noconfirm,
         [Parameter (Mandatory = $False)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$connection = $DefaultArubaSWConnection
@@ -224,20 +223,8 @@ function Disconnect-ArubaSW {
 
         $uri = "rest/v3/login-sessions"
 
-        if ( -not ( $Noconfirm )) {
-            $message = "Remove Aruba Switch connection."
-            $question = "Proceed with removal of Aruba Switch connection ?"
-            $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
-
-            $decision = $Host.UI.PromptForChoice($message, $question, $choices, 1)
-        }
-        else { $decision = 0 }
-        if ($decision -eq 0) {
-            Write-Progress -activity "Remove Aruba SW connection"
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Remove Connection')) {
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -uri $uri -connection $connection
-            Write-Progress -activity "Remove Aruba SW connection" -completed
             if (Test-Path variable:global:DefaultArubaSWConnection) {
                 Remove-Variable -name DefaultArubaSWConnection -scope global
             }

--- a/PowerArubaSW/Public/LACP.ps1
+++ b/PowerArubaSW/Public/LACP.ps1
@@ -119,19 +119,18 @@ function Remove-ArubaSWLACP {
         Remove port 3 of the lacp trunk group trk6.
 
         .EXAMPLE
-        Remove-ArubaSWLACP -trunk_group trk6 -port 3 -noconfirm
-        PS C:\>Remove-ArubaSWLACP -trunk_group trk6 -port 5 -noconfirm
+        Remove-ArubaSWLACP -trunk_group trk6 -port 3 -confirm:$false
+        PS C:\>Remove-ArubaSWLACP -trunk_group trk6 -port 5 -confirm:$false
 
         Remove ports 3 and 5 in trunk group 6 without confirmation.
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'high')]
     Param(
         [Parameter (Mandatory = $true, Position = 1)]
         [string]$trunk_group,
         [Parameter (Mandatory = $true, Position = 2)]
         [string]$port,
-        [Parameter(Mandatory = $false)]
-        [switch]$noconfirm,
         [Parameter (Mandatory = $False)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$connection = $DefaultArubaSWConnection
@@ -152,20 +151,8 @@ function Remove-ArubaSWLACP {
 
         $uri = "rest/v4/lacp/port/${id}"
 
-        if ( -not ( $Noconfirm )) {
-            $message = "Remove LACP on switch"
-            $question = "Proceed with removal of LACP ${id} ?"
-            $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
-
-            $decision = $Host.UI.PromptForChoice($message, $question, $choices, 1)
-        }
-        else { $decision = 0 }
-        if ($decision -eq 0) {
-            Write-Progress -activity "Remove LACP"
+        if ($PSCmdlet.ShouldProcess($id, 'Remove LACP')) {
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -body $lacp -uri $uri -connection $connection
-            Write-Progress -activity "Remove LACP" -completed
         }
     }
 

--- a/PowerArubaSW/Public/LLDP.ps1
+++ b/PowerArubaSW/Public/LLDP.ps1
@@ -167,7 +167,7 @@ function Set-ArubaSWLLDPGlobalStatus {
 
         $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
 
-        if ($PSCmdlet.ShouldProcess("", 'Configure LLDP Global Status')) {
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Configure LLDP Global Status')) {
             $run = $response | ConvertFrom-Json
 
             $run

--- a/PowerArubaSW/Public/LLDP.ps1
+++ b/PowerArubaSW/Public/LLDP.ps1
@@ -115,6 +115,7 @@ function Set-ArubaSWLLDPGlobalStatus {
         Set LLDP disable and configure holdtime to 10 and faststart to 1
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $false)]
         [switch]$enable,
@@ -166,10 +167,11 @@ function Set-ArubaSWLLDPGlobalStatus {
 
         $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
 
-        $run = $response | ConvertFrom-Json
+        if ($PSCmdlet.ShouldProcess("", 'Configure LLDP Global Status')) {
+            $run = $response | ConvertFrom-Json
 
-        $run
-
+            $run
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/Led.ps1
+++ b/PowerArubaSW/Public/Led.ps1
@@ -147,7 +147,7 @@ function Set-ArubaSWLed {
             $led | Add-Member -name "member_id" -membertype NoteProperty -Value $member_id
         }
 
-        if (($PSCmdlet.ShouldProcess($connection.server), 'Configure Led')) {
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Configure Led')) {
             Invoke-ArubaSWWebRequest -method "POST" -body $led -uri $uri -connection $connection | Out-Null
 
             #Display the led info...

--- a/PowerArubaSW/Public/Led.ps1
+++ b/PowerArubaSW/Public/Led.ps1
@@ -80,6 +80,7 @@ function Set-ArubaSWLed {
         Enable Led Locator on member stack 2 (for stack unit)
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true)]
         [ValidateSet("On", "Off", "Blink")]
@@ -146,11 +147,12 @@ function Set-ArubaSWLed {
             $led | Add-Member -name "member_id" -membertype NoteProperty -Value $member_id
         }
 
-        Invoke-ArubaSWWebRequest -method "POST" -body $led -uri $uri -connection $connection | Out-Null
+        if (($PSCmdlet.ShouldProcess($connection.server), 'Configure Led')) {
+            Invoke-ArubaSWWebRequest -method "POST" -body $led -uri $uri -connection $connection | Out-Null
 
-        #Display the led info...
-        Get-ArubaSWLed -connection $connection
-
+            #Display the led info...
+            Get-ArubaSWLed -connection $connection
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/Poe.ps1
+++ b/PowerArubaSW/Public/Poe.ps1
@@ -80,6 +80,7 @@ function Set-ArubaSWPoE {
 
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, ParameterSetName = "port_id")]
         [string]$port_id,
@@ -176,10 +177,12 @@ function Set-ArubaSWPoE {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_poe -uri $uri -connection $connection
-        $rep_poe = ($response.Content | ConvertFrom-Json)
+        if ($PSCmdlet.ShouldProcess("", 'Configure Banner')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_poe -uri $uri -connection $connection
+            $rep_poe = ($response.Content | ConvertFrom-Json)
 
-        $rep_poe
+            $rep_poe
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/Port.ps1
+++ b/PowerArubaSW/Public/Port.ps1
@@ -135,6 +135,7 @@ function Set-ArubaSWPort {
         Configure port 3 to Mode 100 HDX
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, ParameterSetName = "port_id")]
         [string]$port_id,
@@ -211,9 +212,11 @@ function Set-ArubaSWPort {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_port -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess("", 'Configure Port')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_port -uri $uri -connection $connection
 
-        $response | ConvertFrom-Json
+            $response | ConvertFrom-Json
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/Port.ps1
+++ b/PowerArubaSW/Public/Port.ps1
@@ -212,7 +212,7 @@ function Set-ArubaSWPort {
             }
         }
 
-        if ($PSCmdlet.ShouldProcess("", 'Configure Port')) {
+        if ($PSCmdlet.ShouldProcess($port_id, 'Configure Port')) {
             $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_port -uri $uri -connection $connection
 
             $response | ConvertFrom-Json

--- a/PowerArubaSW/Public/RADIUSProfile.ps1
+++ b/PowerArubaSW/Public/RADIUSProfile.ps1
@@ -137,7 +137,7 @@ function Set-ArubaSWRadiusProfile {
             }
         }
 
-        if ($PSCmdlet.ShouldProcess("", 'Configure RADIUS Profile')) {
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Configure RADIUS Profile')) {
             $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
 
             $run = $response | ConvertFrom-Json

--- a/PowerArubaSW/Public/RADIUSProfile.ps1
+++ b/PowerArubaSW/Public/RADIUSProfile.ps1
@@ -68,6 +68,7 @@ function Set-ArubaSWRadiusProfile {
         Enable RADIUS Tracking
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $false)]
         [ValidateRange(1, 15)]
@@ -136,11 +137,13 @@ function Set-ArubaSWRadiusProfile {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess("", 'Configure RADIUS Profile')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
 
-        $run = $response | ConvertFrom-Json
+            $run = $response | ConvertFrom-Json
 
-        $run
+            $run
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/RADIUSServer.ps1
+++ b/PowerArubaSW/Public/RADIUSServer.ps1
@@ -205,6 +205,7 @@ function Set-ArubaSWRadiusServer {
         Enable OOBM on RADIUS Server id 3
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "id")]
         [ValidateRange (1, 15)]
@@ -290,11 +291,13 @@ function Set-ArubaSWRadiusServer {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess($id, 'Configure RADIUS Server')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $conf -uri $uri -connection $connection
 
-        $run = $response | ConvertFrom-Json
+            $run = $response | ConvertFrom-Json
 
-        $run
+            $run
+        }
     }
 
     End {
@@ -317,19 +320,18 @@ function Remove-ArubaSWRadiusServer {
         Remove the RADIUS server with IP Address 192.0.2.2
 
         .EXAMPLE
-        Remove-ArubaSWRadiusServer -id 1 -noconfirm
+        Remove-ArubaSWRadiusServer -id 1 -confirm:$false
 
         Remove the RADIUS server with id 1 without confirmation
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'high')]
     Param(
         [Parameter (Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "id")]
         [ValidateRange (1, 15)]
         [int]$id,
         [Parameter (Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "id_server")]
         [psobject]$id_server,
-        [Parameter(Mandatory = $false)]
-        [switch]$noconfirm,
         [ValidateNotNullOrEmpty()]
         [PSObject]$connection = $DefaultArubaSWConnection
     )
@@ -345,20 +347,8 @@ function Remove-ArubaSWRadiusServer {
 
         $uri = "rest/v4/radius_servers/${id}"
 
-        if ( -not ( $Noconfirm )) {
-            $message = "Remove RADIUS Server on switch"
-            $question = "Proceed with removal of RADIUS server $id ?"
-            $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
-
-            $decision = $Host.UI.PromptForChoice($message, $question, $choices, 1)
-        }
-        else { $decision = 0 }
-        if ($decision -eq 0) {
-            Write-Progress -activity "Remove RADIUS Server"
+        if ($PSCmdlet.ShouldProcess($id, 'Remove RADIUS Server')) {
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -uri $uri -connection $connection
-            Write-Progress -activity "Remove RADIUS Server" -completed
         }
     }
 

--- a/PowerArubaSW/Public/RADIUSServerGroup.ps1
+++ b/PowerArubaSW/Public/RADIUSServerGroup.ps1
@@ -149,18 +149,17 @@ function Remove-ArubaSWRadiusServerGroup {
         Remove the radius server group with name PowerArubaSW.
 
         .EXAMPLE
-        Remove-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW -noconfirm
+        Remove-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW -confirm:$false
 
         Remove the radius server group with name PowerArubaSW without confirmation.
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'high')]
     Param(
         [Parameter (Mandatory = $true, ParameterSetName = "server_group_name")]
         [string]$server_group_name,
         [Parameter (Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = "server_group")]
         [psobject]$server_group,
-        [Parameter(Mandatory = $false)]
-        [switch]$noconfirm,
         [Parameter (Mandatory = $False)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$connection = $DefaultArubaSWConnection
@@ -177,20 +176,8 @@ function Remove-ArubaSWRadiusServerGroup {
 
         $uri = "rest/v4/radius/server_group/${server_group_name}"
 
-        if ( -not ( $Noconfirm )) {
-            $message = "Remove RADIUS Server Group on switch"
-            $question = "Proceed with removal of RADIUS server Group $server_group_name ?"
-            $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
-
-            $decision = $Host.UI.PromptForChoice($message, $question, $choices, 1)
-        }
-        else { $decision = 0 }
-        if ($decision -eq 0) {
-            Write-Progress -activity "Remove RADIUS Server Group"
+        if ($PSCmdlet.ShouldProcess($server_group_name, 'Remove RADIUS Server Group')) {
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -uri $uri -connection $connection
-            Write-Progress -activity "Remove RADIUS Server Group" -completed
         }
     }
 

--- a/PowerArubaSW/Public/RestTimeout.ps1
+++ b/PowerArubaSW/Public/RestTimeout.ps1
@@ -86,7 +86,7 @@ function Set-ArubaSWRestSessionTimeout {
             $time | Add-Member -name "timeout" -membertype NoteProperty -Value $timeout
         }
 
-        if ($PSCmdlet.ShouldProcess("", 'Configure REST Timeout')) {
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Configure REST Timeout')) {
             $response = Invoke-ArubaSWWebRequest -method "PUT" -body $time -uri $uri -connection $connection
 
             $run = ($response | ConvertFrom-Json).timeout

--- a/PowerArubaSW/Public/RestTimeout.ps1
+++ b/PowerArubaSW/Public/RestTimeout.ps1
@@ -63,6 +63,7 @@ function Set-ArubaSWRestSessionTimeout {
         This function allow you to set idle time (in seconds) before being disconnected with the parameter timeout.
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, Position = 1)]
         [ValidateRange(120, 7200)]
@@ -85,12 +86,13 @@ function Set-ArubaSWRestSessionTimeout {
             $time | Add-Member -name "timeout" -membertype NoteProperty -Value $timeout
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $time -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess("", 'Configure REST Timeout')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $time -uri $uri -connection $connection
 
-        $run = ($response | ConvertFrom-Json).timeout
+            $run = ($response | ConvertFrom-Json).timeout
 
-        $run
-
+            $run
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/STP.ps1
+++ b/PowerArubaSW/Public/STP.ps1
@@ -63,6 +63,7 @@ function Set-ArubaSWSTP {
         Set the spanning-tree protocol off, the priority to 4 and the mode to RPVST
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, Position = 1)]
         [switch]$enable,
@@ -112,12 +113,13 @@ function Set-ArubaSWSTP {
             $_stp | Add-Member -name "mode" -membertype NoteProperty -Value $_mode
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_stp -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess($connection.server, 'Configure STP')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_stp -uri $uri -connection $connection
 
-        $run = $response | ConvertFrom-Json
+            $run = $response | ConvertFrom-Json
 
-        $run
-
+            $run
+        }
     }
 
     End {
@@ -201,6 +203,7 @@ function Set-ArubaSWSTPPort {
         Configure the port 4 and set the priority 6, enable admin edge, and disable bpdu protection, bpdu filter and root guard.
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, ParameterSetName = "port_id")]
         [string]$port,
@@ -279,11 +282,13 @@ function Set-ArubaSWSTPPort {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_stp -uri $uri -connection $connection
+        if ($PSCmdlet.ShouldProcess($port, 'Configure STP Port')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_stp -uri $uri -connection $connection
 
-        $run = $response | ConvertFrom-Json
+            $run = $response | ConvertFrom-Json
 
-        $run
+            $run
+        }
 
     }
 

--- a/PowerArubaSW/Public/System.ps1
+++ b/PowerArubaSW/Public/System.ps1
@@ -59,6 +59,7 @@ function Set-ArubaSWSystem {
 
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter(Mandatory = $false)]
         [String]$name,
@@ -92,9 +93,11 @@ function Set-ArubaSWSystem {
             $system | Add-Member -name "contact" -membertype NoteProperty -Value $contact
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -uri $uri -Body $system -connection $connection
+        if ($PSCmdlet.ShouldProcess($port, 'Configure STP Port')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -uri $uri -Body $system -connection $connection
 
-        $response.content | ConvertFrom-Json
+            $response.content | ConvertFrom-Json
+        }
     }
 
     End {

--- a/PowerArubaSW/Public/Trunk.ps1
+++ b/PowerArubaSW/Public/Trunk.ps1
@@ -125,13 +125,12 @@ function Remove-ArubaSWTrunk {
         Remove ports 3 and 5 in trunk group 6 without confirm
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'high')]
     Param(
         [Parameter (Mandatory = $true, Position = 1)]
         [string]$trunk_group,
         [Parameter (Mandatory = $true, Position = 2)]
         [string]$port,
-        [Parameter(Mandatory = $false)]
-        [switch]$noconfirm,
         [Parameter (Mandatory = $False)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$connection = $DefaultArubaSWConnection
@@ -152,20 +151,8 @@ function Remove-ArubaSWTrunk {
 
         $uri = "rest/v4/trunk/port/${id}"
 
-        if ( -not ( $Noconfirm )) {
-            $message = "Remove trunk group on switch"
-            $question = "Proceed with removal of trunk group $trunk_group on port $port ?"
-            $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
-
-            $decision = $Host.UI.PromptForChoice($message, $question, $choices, 1)
-        }
-        else { $decision = 0 }
-        if ($decision -eq 0) {
-            Write-Progress -activity "Remove trunk group"
+        if ($PSCmdlet.ShouldProcess($id, 'Remove Trunk')) {
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -body $trunk -uri $uri -connection $connection
-            Write-Progress -activity "Remove trunk group" -completed
         }
     }
 

--- a/PowerArubaSW/Public/Vlans.ps1
+++ b/PowerArubaSW/Public/Vlans.ps1
@@ -260,7 +260,7 @@ function Set-ArubaSWVlans {
 }
 
 function Remove-ArubaSWVlans {
-
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     <#
         .SYNOPSIS
         Remove a Vlan on ArubaOS Switch (Provision)
@@ -286,13 +286,10 @@ function Remove-ArubaSWVlans {
         [Parameter (Mandatory = $true, ValueFromPipeline = $true, Position = 1, ParameterSetName = "vlan")]
         #ValidateScript({ ValidateVlan $_ })]
         [psobject]$vlan,
-        [Parameter(Mandatory = $false)]
-        [switch]$noconfirm,
         [Parameter (Mandatory = $False)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$connection = $DefaultArubaSWConnection
     )
-
     Begin {
     }
 
@@ -305,17 +302,8 @@ function Remove-ArubaSWVlans {
 
         $uri = "rest/v4/vlans/${id}"
 
-        if ( -not ( $Noconfirm )) {
-            $message = "Remove Vlan on switch"
-            $question = "Proceed with removal of vlan ${id} ?"
-            $choices = New-Object Collections.ObjectModel.Collection[Management.Automation.Host.ChoiceDescription]
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&Yes'))
-            $choices.Add((New-Object Management.Automation.Host.ChoiceDescription -ArgumentList '&No'))
-
-            $decision = $Host.UI.PromptForChoice($message, $question, $choices, 1)
-        }
-        else { $decision = 0 }
-        if ($decision -eq 0) {
+        $target = "Vlan ID {0}" -f $id
+        if ($PSCmdlet.ShouldProcess($target, "Remove VLAN")) {
             Write-Progress -activity "Remove Vlan"
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -uri $uri -connection $connection
             Write-Progress -activity "Remove Vlan" -completed

--- a/PowerArubaSW/Public/Vlans.ps1
+++ b/PowerArubaSW/Public/Vlans.ps1
@@ -262,7 +262,7 @@ function Set-ArubaSWVlans {
 }
 
 function Remove-ArubaSWVlans {
-    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+
     <#
         .SYNOPSIS
         Remove a Vlan on ArubaOS Switch (Provision)
@@ -282,6 +282,7 @@ function Remove-ArubaSWVlans {
         Remove vlan id 85 with no confirmation
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
     Param(
         [Parameter (Mandatory = $true, ParameterSetName = "id")]
         [int]$id,
@@ -306,9 +307,7 @@ function Remove-ArubaSWVlans {
 
         $target = "Vlan ID {0}" -f $id
         if ($PSCmdlet.ShouldProcess($target, "Remove VLAN")) {
-            Write-Progress -activity "Remove Vlan"
             $null = Invoke-ArubaSWWebRequest -method "DELETE" -uri $uri -connection $connection
-            Write-Progress -activity "Remove Vlan" -completed
         }
     }
 

--- a/PowerArubaSW/Public/Vlans.ps1
+++ b/PowerArubaSW/Public/Vlans.ps1
@@ -275,7 +275,7 @@ function Remove-ArubaSWVlans {
         Remove vlan id 85
 
         .EXAMPLE
-        Remove-ArubaSWVlans -id 85 -noconfirm
+        Remove-ArubaSWVlans -id 85 -confirm:$false
 
         Remove vlan id 85 with no confirmation
     #>

--- a/PowerArubaSW/Public/Vlans.ps1
+++ b/PowerArubaSW/Public/Vlans.ps1
@@ -172,6 +172,7 @@ function Set-ArubaSWVlans {
 
     #>
 
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'medium')]
     Param(
         [Parameter (Mandatory = $true, ParameterSetName = "id")]
         [int]$id,
@@ -220,7 +221,6 @@ function Set-ArubaSWVlans {
 
             $_vlan | Add-Member -name "name" -membertype NoteProperty -Value $oldname
         }
-        $name
 
         if ( $PsBoundParameters.ContainsKey('is_voice_enabled') ) {
             if ( $is_voice_enabled ) {
@@ -249,10 +249,12 @@ function Set-ArubaSWVlans {
             }
         }
 
-        $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_vlan -uri $uri -connection $connection
-        $rep_vlan = ($response.Content | ConvertFrom-Json)
+        if ($PSCmdlet.ShouldProcess($id, 'Configure Vlans')) {
+            $response = Invoke-ArubaSWWebRequest -method "PUT" -body $_vlan -uri $uri -connection $connection
+            $rep_vlan = ($response.Content | ConvertFrom-Json)
 
-        $rep_vlan
+            $rep_vlan
+        }
     }
 
     End {

--- a/Tests/common.ps1
+++ b/Tests/common.ps1
@@ -103,4 +103,4 @@ if ('ST_STACKED' -eq $defaultArubaSWConnection.switch_type) {
     $script:pester_poe_port = "$pester_stack_module/$pester_poe_port"
 }
 
-Disconnect-ArubaSW -noconfirm
+Disconnect-ArubaSW -confirm:$false

--- a/Tests/integration/Banner.Tests.ps1
+++ b/Tests/integration/Banner.Tests.ps1
@@ -73,5 +73,5 @@ Describe  "Configure Banner" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Cli.Tests.ps1
+++ b/Tests/integration/Cli.Tests.ps1
@@ -101,5 +101,5 @@ Describe  "Get-ArubaSWCliBatchStatus" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Connection.Tests.ps1
+++ b/Tests/integration/Connection.Tests.ps1
@@ -16,7 +16,7 @@ Describe  "Connect to a switch (using HTTP)" {
         $DefaultArubaSWConnection.session | Should -Not -BeNullOrEmpty
     }
     It "Disconnect to a switch (using HTTP) and check global variable" {
-        Disconnect-ArubaSW -noconfirm
+        Disconnect-ArubaSW -confirm:$false
         $DefaultArubaSWConnection | Should -Be $null
     }
     #TODO: Connect using wrong login/password
@@ -34,7 +34,7 @@ Describe  "Connect to a switch (using HTTPS)" {
         $DefaultArubaSWConnection.session | Should -Not -BeNullOrEmpty
     }
     It "Disconnect to a switch (using HTTPS) and check global variable" -Skip:($httpOnly) {
-        Disconnect-ArubaSW -noconfirm
+        Disconnect-ArubaSW -confirm:$false
         $DefaultArubaSWConnection | Should -Be $null
     }
     #This test only work with PowerShell 6 / Core (-SkipCertificateCheck don't change global variable but only Invoke-WebRequest/RestMethod)
@@ -90,7 +90,7 @@ Describe  "Connect to a switch (using multi connection)" {
     }
 
     It "Disconnect to a switch (Multi connection)" {
-        Disconnect-ArubaSW -connection $sw -noconfirm
+        Disconnect-ArubaSW -connection $sw -confirm:$false
         $DefaultArubaSWConnection | Should -Be $null
     }
 

--- a/Tests/integration/DNS.Tests.ps1
+++ b/Tests/integration/DNS.Tests.ps1
@@ -82,5 +82,5 @@ Describe  "Remove-ArubaSWDns" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/DNS.Tests.ps1
+++ b/Tests/integration/DNS.Tests.ps1
@@ -20,7 +20,7 @@ Describe  "Set-ArubaSWDns" {
 
     BeforeEach {
         #Always DNS Settings...
-        Remove-ArubaSWDns -noconfirm
+        Remove-ArubaSWDns -confirm:$false
     }
 
     It "Set ArubaSWDns ip server 1" {
@@ -64,7 +64,7 @@ Describe  "Set-ArubaSWDns" {
 
     AfterAll {
         #Always DNS Settings...
-        Remove-ArubaSWDns -noconfirm
+        Remove-ArubaSWDns -confirm:$false
     }
 
 }
@@ -72,7 +72,7 @@ Describe  "Set-ArubaSWDns" {
 Describe  "Remove-ArubaSWDns" {
     It "Remove ArubaSWDns" {
         Set-ArubaSWDns -mode Manual -server1 1.1.1.1 -server2 8.8.8.8 -domain example.org
-        Remove-ArubaSWDns -noconfirm
+        Remove-ArubaSWDns -confirm:$false
         $dns = Get-ArubaSWDns
         $dns.dns_config_mode | Should -Be "DCM_DISABLED"
         $dns.server_1 | Should -BeNullOrEmpty

--- a/Tests/integration/IpAddress.Tests.ps1
+++ b/Tests/integration/IpAddress.Tests.ps1
@@ -25,5 +25,5 @@ Describe  "Get-ArubaSWIPAddress" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/LACP.Tests.ps1
+++ b/Tests/integration/LACP.Tests.ps1
@@ -53,5 +53,5 @@ Describe  "Remove Aruba LACP" {
 
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/LACP.Tests.ps1
+++ b/Tests/integration/LACP.Tests.ps1
@@ -23,31 +23,31 @@ Describe  "Add ArubaSWLACP" {
         $lacp = Get-ArubaSWLACP | Where-Object port_id -eq $pester_lacp_port
         $lacp.port_id | Should -Be "$pester_lacp_port"
         $lacp.trunk_group | Should -Be "$pester_lacp_trk1"
-        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -noconfirm
+        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -confirm:$false
     }
 
     It "Change trunk group on a port without removing it before" {
         Add-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port
         { Add-ArubaSWLACP -trunk_group $pester_lacp_trk2 -port $pester_lacp_port 3> $null } | Should -Throw
-        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -noconfirm
+        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -confirm:$false
     }
 
     It "Change trunk group on a port after removing this port of the trunk group" {
         Add-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port
-        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -noconfirm
+        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -confirm:$false
         { Add-ArubaSWLACP -trunk_group $pester_lacp_trk2 -port $pester_lacp_port } | Should -Not -Throw
-        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk2 -port $pester_lacp_port -noconfirm
+        Remove-ArubaSWLACP -trunk_group $pester_lacp_trk2 -port $pester_lacp_port -confirm:$false
     }
 }
 
 Describe  "Remove Aruba LACP" {
     It "Remove ArubaSWLACP does throw an error if trunk group doesn't exist on a port" {
-        { Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -noconfirm 3> $null } | Should -Throw
+        { Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -confirm:$false 3> $null } | Should -Throw
     }
 
     It "Remove ArubaSWLACP does not throw an error if the trunk group exist on a port" {
         Add-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port
-        { Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -noconfirm } | Should -Not -Throw
+        { Remove-ArubaSWLACP -trunk_group $pester_lacp_trk1 -port $pester_lacp_port -confirm:$false } | Should -Not -Throw
     }
 }
 

--- a/Tests/integration/LLDP.Tests.ps1
+++ b/Tests/integration/LLDP.Tests.ps1
@@ -128,5 +128,5 @@ Describe  "Set LLDPGlobalStatus" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Led.Tests.ps1
+++ b/Tests/integration/Led.Tests.ps1
@@ -107,5 +107,5 @@ Describe  "Configure Led Locator" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/MacTable.Tests.ps1
+++ b/Tests/integration/MacTable.Tests.ps1
@@ -78,5 +78,5 @@ Describe  "Get Mac Table" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Modules.Tests.ps1
+++ b/Tests/integration/Modules.Tests.ps1
@@ -25,5 +25,5 @@ Describe  "Get-ArubaSWModules" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Ping.Tests.ps1
+++ b/Tests/integration/Ping.Tests.ps1
@@ -56,5 +56,5 @@ Describe  "Ping (-hostname)" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Ping.Tests.ps1
+++ b/Tests/integration/Ping.Tests.ps1
@@ -32,7 +32,7 @@ Describe  "Ping (-hostname)" {
 
     BeforeAll {
         #Always remove DNS Settings...
-        Remove-ArubaSWDns -noconfirm
+        Remove-ArubaSWDns -confirm:$false
     }
 
     It "Ping a hostname (without DNS config)" {
@@ -50,7 +50,7 @@ Describe  "Ping (-hostname)" {
 
     AfterAll {
         #Always remove DNS Settings...
-        Remove-ArubaSWDns -noconfirm
+        Remove-ArubaSWDns -confirm:$false
     }
 
 }

--- a/Tests/integration/PoE.Tests.ps1
+++ b/Tests/integration/PoE.Tests.ps1
@@ -106,5 +106,5 @@ Describe  "Get PoE Stats" {
     }
 }
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Port.Tests.ps1
+++ b/Tests/integration/Port.Tests.ps1
@@ -186,5 +186,5 @@ Describe  "Get Port Statistics" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/RADIUSProfile.Tests.ps1
+++ b/Tests/integration/RADIUSProfile.Tests.ps1
@@ -78,5 +78,5 @@ Describe  "Configure RADIUS Profile" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/RADIUSServer.Tests.ps1
+++ b/Tests/integration/RADIUSServer.Tests.ps1
@@ -155,5 +155,5 @@ Describe  "Remove RADIUS Server" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/RADIUSServer.Tests.ps1
+++ b/Tests/integration/RADIUSServer.Tests.ps1
@@ -49,7 +49,7 @@ Describe  "Add RADIUS Server" {
 
     AfterEach {
         $radius = Get-ArubaSWRadiusServer -address 192.0.2.1
-        Remove-ArubaSWRadiusServer -id $radius.radius_server_id -noconfirm
+        Remove-ArubaSWRadiusServer -id $radius.radius_server_id -confirm:$false
     }
 }
 
@@ -125,7 +125,7 @@ Describe  "Configure RADIUS Server" {
 
     AfterAll {
         $radius = Get-ArubaSWRadiusServer -address 192.0.2.1
-        Remove-ArubaSWRadiusServer -id $radius.radius_server_id -noconfirm
+        Remove-ArubaSWRadiusServer -id $radius.radius_server_id -confirm:$false
     }
 }
 
@@ -139,7 +139,7 @@ Describe  "Remove RADIUS Server" {
         It "Remove ArubaSWRadiusServer server" {
 
             $id_server = Get-ArubaSWRadiusServer -address 192.0.2.1
-            Remove-ArubaSWRadiusServer -id $id_server.radius_server_id -noconfirm
+            Remove-ArubaSWRadiusServer -id $id_server.radius_server_id -confirm:$false
             $radius = Get-ArubaSWRadiusServer -address 192.0.2.1
             $radius | Should -BeNullOrEmpty
         }
@@ -147,7 +147,7 @@ Describe  "Remove RADIUS Server" {
 
     Context "Remove RADIUS server by pipeline" {
         It "Remove ArubaSWRadiusServer server" {
-            Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -noconfirm
+            Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -confirm:$false
             $radius = Get-ArubaSWRadiusServer -address 192.0.2.1
             $radius | Should -BeNullOrEmpty
         }

--- a/Tests/integration/RADIUSServerGroup.Tests.ps1
+++ b/Tests/integration/RADIUSServerGroup.Tests.ps1
@@ -23,8 +23,8 @@ Describe  "Get RADIUS Server Group" {
     }
 
     AfterAll {
-        Remove-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW -noconfirm
-        Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -noconfirm
+        Remove-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW -confirm:$false
+        Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -confirm:$false
     }
 
 }
@@ -51,12 +51,12 @@ Describe  "Add RADIUS Server Group" {
     }
 
     AfterEach {
-        Remove-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW -noconfirm
+        Remove-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW -confirm:$false
     }
 
     AfterAll {
-        Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -noconfirm
-        Get-ArubaSWRadiusServer -address 192.0.2.2 | Remove-ArubaSWRadiusServer -noconfirm
+        Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -confirm:$false
+        Get-ArubaSWRadiusServer -address 192.0.2.2 | Remove-ArubaSWRadiusServer -confirm:$false
     }
 }
 
@@ -72,7 +72,7 @@ Describe  "Remove RADIUS Server Group" {
         It "Remove RADIUS Server Group" {
 
             $radius_group = Get-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW
-            Remove-ArubaSWRadiusServerGroup -server_group_name $radius_group.server_group_name -noconfirm
+            Remove-ArubaSWRadiusServerGroup -server_group_name $radius_group.server_group_name -confirm:$false
             { Get-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW 3> $null } | Should -Throw
         }
 
@@ -81,14 +81,14 @@ Describe  "Remove RADIUS Server Group" {
     Context "Remove RADIUS Server Group via pipeline" {
 
         It "Remove RADIUS Server Group" {
-            Get-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW | Remove-ArubaSWRadiusServerGroup -noconfirm
+            Get-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW | Remove-ArubaSWRadiusServerGroup -confirm:$false
             { Get-ArubaSWRadiusServerGroup -server_group_name PowerArubaSW 3> $null } | Should -Throw
         }
 
     }
 
     AfterEach {
-        Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -noconfirm
+        Get-ArubaSWRadiusServer -address 192.0.2.1 | Remove-ArubaSWRadiusServer -confirm:$false
     }
 }
 

--- a/Tests/integration/RADIUSServerGroup.Tests.ps1
+++ b/Tests/integration/RADIUSServerGroup.Tests.ps1
@@ -93,5 +93,5 @@ Describe  "Remove RADIUS Server Group" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/RestTimeout.Tests.ps1
+++ b/Tests/integration/RestTimeout.Tests.ps1
@@ -54,5 +54,5 @@ Describe  "Set RestSessionTimeout" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/RestVersion.Tests.ps1
+++ b/Tests/integration/RestVersion.Tests.ps1
@@ -25,5 +25,5 @@ Describe  "Get-ArubaSWRestVersion" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Stp.Tests.ps1
+++ b/Tests/integration/Stp.Tests.ps1
@@ -105,5 +105,5 @@ Describe  "Configure Spanning Tree Port" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/System.Tests.ps1
+++ b/Tests/integration/System.Tests.ps1
@@ -148,5 +148,5 @@ Describe  "Get System Status Switch" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Trunk.Tests.ps1
+++ b/Tests/integration/Trunk.Tests.ps1
@@ -52,5 +52,5 @@ Describe  "Remove Aruba Trunk" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Trunk.Tests.ps1
+++ b/Tests/integration/Trunk.Tests.ps1
@@ -23,31 +23,31 @@ Describe  "Add Aruba Trunk" {
         $Trunk = Get-ArubaSWTrunk | Where-Object port_id -eq $pester_trunk_port
         $Trunk.port_id | Should -Be "$pester_trunk_port"
         $Trunk.trunk_group | Should -Be "$pester_trunk_trk1"
-        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -noconfirm
+        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -confirm:$false
     }
 
     It "Change trunk group $pester_trunk_trk1 on a port without removing it before" {
         Add-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port
         { Add-ArubaSWTrunk -trunk_group $pester_trunk_trk2 -port $pester_trunk_port 3> $null } | Should -Throw
-        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -noconfirm
+        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -confirm:$false
     }
 
     It "Change trunk group $pester_trunk_trk2 on a port after removing this port of the trunk group" {
         Add-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port
-        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -noconfirm
+        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -confirm:$false
         { Add-ArubaSWTrunk -trunk_group $pester_trunk_trk2 -port $pester_trunk_port } | Should -Not -Throw
-        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -noconfirm
+        Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -confirm:$false
     }
 }
 
 Describe  "Remove Aruba Trunk" {
     It "Remove ArubaSWTrunk does throw an error if trunk group doesn't exist on a port" {
-        { Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -noconfirm 3> $null } | Should -Throw
+        { Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -confirm:$false 3> $null } | Should -Throw
     }
 
     It "Remove ArubaSWTrunk does not throw an error if the trunk group exist on a port" {
         Add-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port
-        { Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -noconfirm } | Should -Not -Throw
+        { Remove-ArubaSWTrunk -trunk_group $pester_trunk_trk1 -port $pester_trunk_port -confirm:$false } | Should -Not -Throw
     }
 }
 

--- a/Tests/integration/Vlans-Ports.Tests.ps1
+++ b/Tests/integration/Vlans-Ports.Tests.ps1
@@ -40,7 +40,7 @@ Describe  "Get Vlans Ports" {
     }
 
     AfterAll {
-        Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+        Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
     }
 }
 
@@ -67,7 +67,7 @@ Describe  "Configure (Add/Set/Remove) Vlans Ports" {
         }
 
         It "Remove vlan_id $pester_vlan on port_id $pester_vlanport" {
-            Remove-ArubaSWVlansPorts -vlan_id $pester_vlan -port_id $pester_vlanport -noconfirm
+            Remove-ArubaSWVlansPorts -vlan_id $pester_vlan -port_id $pester_vlanport -confirm:$false
             $VLANP = Get-ArubaSWVlansPorts -port_id $pester_vlanport
             $VLANP.vlan_id | Should -Be 1
             $VLANP.port_id | Should -Be $pester_vlanport
@@ -91,7 +91,7 @@ Describe  "Configure (Add/Set/Remove) Vlans Ports" {
         }
 
         It "Remove vlan_id $pester_vlan on port_id $pester_vlanport" {
-            Remove-ArubaSWVlansPorts -vlan_id $pester_vlan -port_id $pester_vlanport -noconfirm
+            Remove-ArubaSWVlansPorts -vlan_id $pester_vlan -port_id $pester_vlanport -confirm:$false
             $VLANP = Get-ArubaSWVlansPorts -port_id $pester_vlanport
             $VLANP.vlan_id | Should -Be 1
             $VLANP.port_id | Should -Be $pester_vlanport
@@ -119,7 +119,7 @@ Describe  "Configure (Add/Set/Remove) Vlans Ports" {
 
         It "Remove vlan_id $pester_vlan on port_id $pester_vlanport" {
             $VLANP = Get-ArubaSWVlansPorts -port_id $pester_vlanport -vlan_id $pester_vlan
-            $VLANP | Remove-ArubaSWVlansPorts -noconfirm
+            $VLANP | Remove-ArubaSWVlansPorts -confirm:$false
             $VLANP = Get-ArubaSWVlansPorts -port_id $pester_vlanport
             $VLANP.vlan_id | Should -Be 1
             $VLANP.port_id | Should -Be $pester_vlanport
@@ -145,7 +145,7 @@ Describe  "Configure (Add/Set/Remove) Vlans Ports" {
 
         It "Remove vlan_id $pester_vlan on port_id $pester_vlanport" {
             $VLANP = Get-ArubaSWVlansPorts -port_id $pester_vlanport -vlan_id $pester_vlan
-            $VLANP | Remove-ArubaSWVlansPorts -noconfirm
+            $VLANP | Remove-ArubaSWVlansPorts -confirm:$false
             $VLANP = Get-ArubaSWVlansPorts -port_id $pester_vlanport
             $VLANP.vlan_id | Should -Be 1
             $VLANP.port_id | Should -Be $pester_vlanport
@@ -154,7 +154,7 @@ Describe  "Configure (Add/Set/Remove) Vlans Ports" {
     }
 
     AfterAll {
-        Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+        Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
     }
 }
 

--- a/Tests/integration/Vlans-Ports.Tests.ps1
+++ b/Tests/integration/Vlans-Ports.Tests.ps1
@@ -159,5 +159,5 @@ Describe  "Configure (Add/Set/Remove) Vlans Ports" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }

--- a/Tests/integration/Vlans.Tests.ps1
+++ b/Tests/integration/Vlans.Tests.ps1
@@ -56,7 +56,7 @@ Describe  "Add VLAN" {
                 #fix stupid issue... when there is already dhcp snoop enable on a vlan, it is not remove (when remove the vlan)...
                 Set-ArubaSWVlans -id $pester_vlan -name PowerArubaSW -is_dsnoop_enabled:$false
             }
-            Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+            Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
         }
     }
 
@@ -107,7 +107,7 @@ Describe  "Add VLAN" {
                 #fix stupid issue... when there is already dhcp snoop enable on a vlan, it is not remove (when remove the vlan)...
                 Set-ArubaSWVlans -id $pester_vlan -name PowerArubaSW -is_dsnoop_enabled:$false
             }
-            Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+            Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
         }
     }
 }
@@ -155,7 +155,7 @@ Describe  "Configure VLAN" {
                     #fix stupid issue... when there is already dhcp snoop enable on a vlan, it is not remove (when remove the vlan)...
                     Set-ArubaSWVlans -id $pester_vlan -name PowerArubaSW -is_dsnoop_enabled:$false
                 }
-                Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+                Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
             }
         }
     }
@@ -203,7 +203,7 @@ Describe  "Configure VLAN" {
                     #fix stupid issue... when there is already dhcp snoop enable on a vlan, it is not remove (when remove the vlan)...
                     Set-ArubaSWVlans -id $pester_vlan -name PowerArubaSW -is_dsnoop_enabled:$false
                 }
-                Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+                Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
             }
         }
 
@@ -218,14 +218,14 @@ Describe  "Remove VLAN" {
     }
 
     It "Remove VLAN $pester_vlan by id" {
-        Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+        Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
         $VLAN = Get-ArubaSWVlans -id $pester_vlan
         $VLAN | Should -Be $NULL
     }
 
     It "Remove VLAN $pester_vlan by pipeline" {
         $VLAN = Get-ArubaSWVlans -id $pester_vlan
-        $VLAN | Remove-ArubaSWVlans -noconfirm
+        $VLAN | Remove-ArubaSWVlans -confirm:$false
         $VLAN = Get-ArubaSWVlans -id $pester_vlan
         $VLAN | Should -Be $NULL
     }
@@ -238,7 +238,7 @@ Describe  "Remove VLAN" {
                 #fix stupid issue... when there is already dhcp snoop enable on a vlan, it is not remove (when remove the vlan)...
                 Set-ArubaSWVlans -id $pester_vlan -name PowerArubaSW -is_dsnoop_enabled:$false
             }
-            Remove-ArubaSWVlans -id $pester_vlan -noconfirm
+            Remove-ArubaSWVlans -id $pester_vlan -confirm:$false
         }
     }
 }

--- a/Tests/integration/Vlans.Tests.ps1
+++ b/Tests/integration/Vlans.Tests.ps1
@@ -244,5 +244,5 @@ Describe  "Remove VLAN" {
 }
 
 AfterAll {
-    Disconnect-ArubaSW -noconfirm
+    Disconnect-ArubaSW -confirm:$false
 }


### PR DESCRIPTION
Hi!

This proposed change adds support for -confirm:$false instead of using internal logic and "-noconfirm" flags.

However you might want to work a bit with the message displayed if its not to your liking.

```powershell
PS > Remove-ArubaSWVLAN -id 10

Confirm
Are you sure you want to perform this action?
Performing the operation "Remove VLAN" on target "Vlan ID 10".
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): n
PS > Remove-ArubaSWVLAN -id 10 -Confirm:$false
PS >
```